### PR TITLE
Add: 周辺店舗検索機能追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,8 @@ gem 'dotenv-rails'
 gem 'google_places'
 # 入力した住所から緯度と経度を取得
 gem "geocoder"
+# Railsで定義した変数をJavaScriptで使用できるようにする
+gem 'gon'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,11 @@ GEM
     geocoder (1.8.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    gon (6.4.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
     google_places (2.0.0)
       httparty (>= 0.13.1)
     hashie (5.0.0)
@@ -171,6 +176,7 @@ GEM
     mini_portile2 (2.8.0)
     minitest (5.16.3)
     msgpack (1.6.0)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     net-imap (0.3.1)
       net-protocol
@@ -243,6 +249,8 @@ GEM
     regexp_parser (2.6.0)
     reline (0.3.1)
       io-console (~> 0.5)
+    request_store (1.5.1)
+      rack (>= 1.4)
     rexml (3.2.5)
     rspec-core (3.12.0)
       rspec-support (~> 3.12.0)
@@ -353,6 +361,7 @@ DEPENDENCIES
   enum_help
   factory_bot_rails
   geocoder
+  gon
   google_places
   jbuilder
   jsbundling-rails

--- a/app/controllers/rodgings_controller.rb
+++ b/app/controllers/rodgings_controller.rb
@@ -12,7 +12,7 @@ class RodgingsController < ApplicationController
   def create
     @rodging = current_user.rodgings.build(rodging_params)
     if @rodging.save
-      redirect_to rodging_path(@rodging)
+      redirect_to search_rodging_shops_path(@rodging)
     else
       render :new
     end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,0 +1,39 @@
+class ShopsController < ApplicationController
+  before_action :set_shop, only: %i[show destroy]
+  before_action :set_rodging, only: %i[new search]
+   
+  def new; end
+
+  def create
+    @shop = Shop.new(shop_params)
+    
+    if @shop.save
+      redirect_to rodging_path
+    else
+      render :new
+    end
+  end
+
+  def show; end
+
+  def destroy
+    @shop.destroy
+    redirect_to rodging_path
+  end
+
+  def search; end
+
+  private
+
+  def set_rodging
+    @rodging = current_user.rodgings.find(params[:rodging_id])
+  end
+
+  def set_shop
+    @shop = current_user.rodgings.shops.find(params[:id])
+  end
+  
+  def shop_params
+    params.require(:shop).permit(:latitude, :longitude, :address)
+  end
+end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,16 +1,16 @@
 class ShopsController < ApplicationController
   before_action :set_shop, only: %i[show destroy]
-  before_action :set_rodging, only: %i[new search]
+  before_action :set_rodging, only: %i[create search]
    
   def new; end
 
   def create
-    @shop = Shop.new(shop_params)
+    @shop = @rodging.shops.build(shop_params)
     
     if @shop.save
-      redirect_to rodging_path
+      redirect_to root_path
     else
-      render :new
+      render :search
     end
   end
 
@@ -21,7 +21,9 @@ class ShopsController < ApplicationController
     redirect_to rodging_path
   end
 
-  def search; end
+  def search
+    @shop = Shop.new
+  end
 
   private
 
@@ -34,6 +36,6 @@ class ShopsController < ApplicationController
   end
   
   def shop_params
-    params.require(:shop).permit(:latitude, :longitude, :address)
+    params.require(:shop).permit(:latitude, :longitude, :address).merge(rodging_id: params[:rodging_id])
   end
 end

--- a/app/models/rodging.rb
+++ b/app/models/rodging.rb
@@ -2,6 +2,7 @@ class Rodging < ApplicationRecord
   geocoded_by :address
   after_validation :geocode
   belongs_to :user
+  has_many :shops, dependent: :destroy
 
   with_options presence: true do
     validates :address

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -1,8 +1,7 @@
 class Shop < ApplicationRecord
+  geocoded_by :address
+  after_validation :geocode
   belongs_to :rodging
 
-  with_options presence: true do
-    validates :name
-    validates :address
-  end
+  validates :address, presence: true
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
       <%= render 'shared/before_login_header' %>
     <% end %>
     <%= render 'shared/flash_message' %>
-    <div class="flex justify-center bg-neutral">
+    <div class="flex justify-center bg-neutral-focus">
       <%= yield %>
     </div>
     <%= render 'shared/footer' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <%= include_gon %>
+
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   </head>

--- a/app/views/rodgings/_rodging.html.erb
+++ b/app/views/rodgings/_rodging.html.erb
@@ -3,7 +3,7 @@
   <div class="card w-96 bg-base-100 font-bold shadow-xl mt-5 mb-5">
     <div class="card-body">
       <button class="text-xl"><%= rodging.address %></button>
-      <div id="map" style="width:325px; height:300px" class="mt-3 mb-3"></div>
+      <div><%= render 'rodging_map', rodging: rodging %></div>
       <div><%= Rodging.human_attribute_name(:start_time)%></div>
       <div class='flex justify-start'>
         <div class='mr-3 mb-3'><%= rodging.start_time.strftime('%Y年%m/%d') %></div>
@@ -19,33 +19,3 @@
     </div>
   </div>
 </div>
-<!-- Googleマップ表示用の Javascript -->
-<script>
-  function initMap(){
-    // 地図の位置情報(緯度・経度)を取得
-    let mapPosition = {lat: <%= rodging.latitude || 0 %> , lng: <%= rodging.longitude || 0 %> };
-    let map = new google.maps.Map(document.getElementById('map'), {
-      zoom: 15,
-      center: mapPosition
-    });
-    let transitLayer = new google.maps.TransitLayer();
-    transitLayer.setMap(map);
-
-    let contentString = '【施設名】<%= rodging.address %>';
-    let infowindow = new google.maps.InfoWindow({
-      content: contentString
-    });
-
-    let marker = new google.maps.Marker({
-      position: mapPosition,
-      map: map,
-      title: contentString
-    });
-
-    marker.addListener('click', function(){
-      infowindow.open(map, marker);
-    });
-  }
-</script>
-
-<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap" async defer></script>

--- a/app/views/rodgings/_rodging.html.erb
+++ b/app/views/rodgings/_rodging.html.erb
@@ -13,7 +13,7 @@
       <div><%= Rodging.human_attribute_name(:shopping_day)%></div>
       <div><%= rodging.shopping_day.strftime('%Y年%m/%d') %></div>
       <div class="card-actions justify-center">
-        <button class="btn btn-secondary"><%= (t'defaults.change')%></button>
+        <button class="btn btn-secondary"><%= (t'defaults.change') %></button>
         <button class="btn btn-primary"><%= (t'defaults.delete')%></button>
       </div>
     </div>

--- a/app/views/rodgings/_rodging_map.html.erb
+++ b/app/views/rodgings/_rodging_map.html.erb
@@ -1,0 +1,32 @@
+<div id="map" style="width:325px; height:300px" class="mt-3 mb-3"></div>
+
+<!-- Googleマップ表示用の Javascript -->
+<script>
+  function initMap(){
+    // 地図の位置情報(緯度・経度)を取得
+    let mapPosition = {lat: <%= rodging.latitude || 0 %> , lng: <%= rodging.longitude || 0 %> };
+    let map = new google.maps.Map(document.getElementById('map'), {
+      zoom: 15,
+      center: mapPosition
+    });
+    let transitLayer = new google.maps.TransitLayer();
+    transitLayer.setMap(map);
+
+    let contentString = '【施設名】<%= rodging.address %>';
+    let infowindow = new google.maps.InfoWindow({
+      content: contentString
+    });
+
+    let marker = new google.maps.Marker({
+      position: mapPosition,
+      map: map,
+      title: contentString
+    });
+
+    marker.addListener('click', function(){
+      infowindow.open(map, marker);
+    });
+  }
+</script>
+
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap" async defer></script>

--- a/app/views/shops/_form.html.erb
+++ b/app/views/shops/_form.html.erb
@@ -1,0 +1,8 @@
+<%= form_with model: shop, url: rodging_shops_path,local: true do |f| %>
+  <div class="mb-2">
+    <%= f.text_field :address, autofocus: true,placeholder: "店舗名を入力してください", class: 'w-full rounded border border-gray-200 p-2' %>
+  </div>
+  <div class="text-center">
+    <%= f.submit (t'defaults.keep'), class: 'btn btn-active' %>
+  </div>
+<% end %>

--- a/app/views/shops/search.html.erb
+++ b/app/views/shops/search.html.erb
@@ -5,6 +5,10 @@
       <div><%= render 'rodgings/rodging_map', rodging: @rodging %></div>
       <input type="text" placeholder="お菓子など" id="search" class="input w-full max-w-xs bg-white" />
       <button class='btn btn-active' onClick="SearchGo()">検索</button>
+      <div class="text-center">
+        <h1 class="font-bold text-4xl">↓</h1>
+      </div>
+      <%= render 'form', shop: @shop %>
     </div>
   </div>
 </div>
@@ -24,7 +28,6 @@
     let myword = document.getElementById("search");
     let request = {
         query: myword.value,
-        radius: 1000,
         location: myMap.getCenter()
     };
     service.textSearch(request, result_search);

--- a/app/views/shops/search.html.erb
+++ b/app/views/shops/search.html.erb
@@ -1,0 +1,69 @@
+<div class="flex flex-col">  
+  <div class="card w-96 bg-base-100 shadow-xl mt-5 mb-5">
+    <div class="card-body">
+      <button class="text-xl"><%= @rodging.address %>周辺で検索</button>
+      <div><%= render 'rodgings/rodging_map', rodging: @rodging %></div>
+      <input type="text" placeholder="お菓子など" id="search" class="input w-full max-w-xs bg-white" />
+      <button class='btn btn-active' onClick="SearchGo()">検索</button>
+    </div>
+  </div>
+</div>
+ 
+<script>
+  function SearchGo() {
+    let initPos = {lat: <%= @rodging.latitude || 0 %> , lng: <%= @rodging.longitude || 0 %> };
+    let mapOptions = {
+        center : initPos,
+        zoom: 0,
+        mapTypeId : google.maps.MapTypeId.ROADMAP
+    };
+    // #map要素にMapクラスの新しいインスタンスを作成
+    myMap = new google.maps.Map(document.getElementById("map"), mapOptions);
+    service = new google.maps.places.PlacesService(myMap);
+    // input要素に入力されたキーワードを検索の条件に設定
+    let myword = document.getElementById("search");
+    let request = {
+        query: myword.value,
+        radius: 1000,
+        location: myMap.getCenter()
+    };
+    service.textSearch(request, result_search);
+  }
+  
+  // 検索の結果を受け取る
+  function result_search(results, status) {
+      let bounds = new google.maps.LatLngBounds();
+      for(let i = 0; i < results.length; i++){
+          createMarker({
+              position : results[i].geometry.location,
+              text : results[i].name,
+              map : myMap
+          });
+          bounds.extend(results[i].geometry.location);
+      }
+      myMap.fitBounds(bounds);
+  }
+  
+  // 該当する位置にマーカーを表示
+  function createMarker(options) {
+      // マップ情報を保持しているmyMapオブジェクトを指定
+      options.map = myMap;
+      // Markcrクラスのオブジェクトmarkerを作成
+      let marker = new google.maps.Marker(options);
+      // 各施設の吹き出し(情報ウインドウ)に表示させる処理
+      let infoWnd = new google.maps.InfoWindow();
+      infoWnd.setContent(options.text);
+      // addListenerメソッドを使ってイベントリスナーを登録
+      google.maps.event.addListener(marker, 'click', function(){
+          infoWnd.open(myMap, marker);
+      });
+      return marker;
+  }
+  
+  // ページ読み込み完了後、Googleマップを表示
+  google.maps.event.addDomListener(window, 'load', initialize);
+</script>
+
+<script async
+    src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&libraries=places&callback=initMap">
+</script>

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Shops#show</h1>
+<p>Find me in app/views/shops/show.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,11 @@ Rails.application.routes.draw do
 
   resources :users, only: %i[new create]
   resource :profile, only: %i[show edit update]
-  resources :rodgings, only: %i[new create index show destroy]
+  resources :rodgings, only: %i[new create index show destroy] do
+    resources :shops, only: %i[new create show destroy] do
+      collection do
+        get 'search'
+      end
+    end
+  end
 end

--- a/spec/controllers/shops_controller_spec.rb
+++ b/spec/controllers/shops_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe ShopsController, type: :controller do
+
+  describe "GET #new" do
+    it "returns http success" do
+      get :new
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET #create" do
+    it "returns http success" do
+      get :create
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET #show" do
+    it "returns http success" do
+      get :show
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET #destroy" do
+    it "returns http success" do
+      get :destroy
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
## 追加内容
- 登録した宿泊施設の周辺検索機能
## 確認方法
- 周辺検索ページで表示したいお土産名をフォームに入れ、検索ボタンを押して表示されるのを確認する
## 備考
- 現在周辺検索をして表示された店舗名をユーザーにフォームに打ち込むようにしてもらう仕様にしているが、本リリース時点ではMapの吹き出しに保存ボタンを設置してDBに保持させたい