### PR TITLE
Fix: 宿泊施設一覧のレイアウト変更

### DIFF
--- a/app/views/rodgings/_form.html.erb
+++ b/app/views/rodgings/_form.html.erb
@@ -10,10 +10,10 @@
     <div class="pt-2 pb-1">
       <%= f.label :start_time, class: 'block mb-1' %>
     </div>
-    <div class="flex">
-      <%= f.datetime_field :start_time, data: { controller: "flatpickr" }, class: 'rounded border border-gray-200 p-2' %>
-      〜
-      <%= f.datetime_field :end_time, data: { controller: "flatpickr" }, class: 'rounded border border-gray-200 p-2' %>
+    <div class="flex justify-start">
+      <%= f.datetime_field :start_time, data: { controller: "flatpickr" }, class: 'rounded border border-gray-200 p-2 mr-2' %>
+      <h1 class='mt-3'>〜</h1>
+      <%= f.datetime_field :end_time, data: { controller: "flatpickr" }, class: 'rounded border border-gray-200 p-2 ml-2' %>
     </div>
   </div>
   <div class="mb-2">

--- a/app/views/rodgings/_rodging.html.erb
+++ b/app/views/rodgings/_rodging.html.erb
@@ -1,6 +1,6 @@
 <div class="card w-96 bg-base-100 font-bold shadow-xl">
   <div class="card-body">
-    <%= link_to rodging.address, rodging_shops_path(rodging.id), class: "text-xl text-center" %>
+    <%= link_to rodging.address, rodging_shops_path(rodging.id), class: "text-xl text-center btn btn-outline" %>
     <div id='map-<%= rodging.id %>' style="width:325px; height:300px" class="mt-3 mb-3"></div>
     <div><%= Rodging.human_attribute_name(:start_time)%></div>
     <div class='flex justify-start'>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -22,7 +22,7 @@
       <% end %>
       <div class="text-center">
         <%= link_to t('.to_signup_page'), new_user_path %>
-        <p class='mt-3'><%= link_to t('.password_foreget'), new_password_reset_path %></p>
+        <p class='mt-3'><%= link_to t('.password_foreget'), '#' %></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 変更内容
- 宿泊施設一覧の宿泊施設名をクリックすると店舗一覧画面に遷移するようにしているが、見た目がただの文字なのでユーザーがクリックできると思うようにないデザインだったため、ボタン風に変更した