### PR TITLE
Fix: 宿泊先一覧の表示を旅行日程が近い順に並び替えた

### DIFF
--- a/app/controllers/rodgings_controller.rb
+++ b/app/controllers/rodgings_controller.rb
@@ -2,7 +2,7 @@ class RodgingsController < ApplicationController
   before_action :set_rodging, only: %i[edit update destroy]
 
   def index
-    @rodgings = current_user.rodgings.all
+    @rodgings = current_user.rodgings.all.order('start_time ASC')
   end
 
   def new


### PR DESCRIPTION
## 変更内容
- 今までは宿泊先一覧に新しく作成した順に並べていたが旅行日程が近い順に並び替えた方がいいかもとの声を頂いたので修正