### PR TITLE
Fix: usersモデルのuniqueness制約削除

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,6 @@ class User < ApplicationRecord
   validates :reset_password_token, uniqueness: true, allow_nil: true
   validates :name, presence: true, length: { minimum: 3, maximum: 20 }
   validates :email, uniqueness: true, presence: true
-  validates :line_user_id, uniqueness: true
 
   enum role: {
     general: 0,


### PR DESCRIPTION
## 変更内容
- herokuでundefindmethodエラーが出るのでuniqueness制約を削除して様子を見る